### PR TITLE
Make chef version explicit

### DIFF
--- a/stacks/community-allinone/Vagrantfile
+++ b/stacks/community-allinone/Vagrantfile
@@ -38,6 +38,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision "chef_solo" do |chef|
+    chef.version = '12.10.24'
     chef.json = instance_template
     instance_template['run_list'].each do |recipe|
       chef.add_recipe recipe


### PR DESCRIPTION
The current stable version of chef (12.11.13) doesn't work so make it explicit as to which version to use - see https://github.com/chef/chef/issues/4948