### PR TITLE
[SRE-196] Corrected tests for if gems were installed - they never worked

### DIFF
--- a/scripts/chef/test-cookbook.sh
+++ b/scripts/chef/test-cookbook.sh
@@ -1,26 +1,23 @@
 #!/bin/bash
 
-function runTests () {
+runTests () {
   echo "[test-cookbook.sh] Running Chef, Foodcritic and ERB syntax check tests"
 
-  gem list > gems.list
+  gem_installer () {
+    local gem=$1
 
-  if grep -L foodcritic gems.list; then
-    gem install foodcritic
-  fi
-  if grep -L rails-erb-check gems.list; then
-    gem install rails-erb-check
-  fi
-  if grep -L jsonlint gems.list; then
-    gem install jsonlint
-  fi
-  if grep -L rubocop gems.list; then
-    gem install rubocop
-  fi
+    gem list --no-installed ${gem} &>> /dev/null
+    if [ $? == 0 ]
+    then
+      gem install ${gem}
+    fi
+  }
 
-  #if grep -L yaml-lint gems.list; then
-    gem install yaml-lint
-  #fi
+  local gem
+  for gem in foodcritic rails-erb-check jsonlint rubocop yaml-lint
+  do
+    gem_installer ${gem}
+  done
 
   find . -not -path '*/\.*' -name "*.erb" -exec rails-erb-check {} \;
   find . -not -path '*/\.*' -name "*.json" -exec jsonlint {} \;
@@ -31,7 +28,6 @@ function runTests () {
   foodcritic -f any .
   # Next one should use warning as fail-level, printing only the progress review
   rubocop --fail-level warn | sed -n 2p
-  rm -rf gems.list
 }
 
 runTests


### PR DESCRIPTION
The following is meaningless. I'm surprised `bash` even accepts it.

``` if grep -L foodcritic gems.list ```

Also, rather than dump the gems to a file and grep them, I thought it better to check using `gem list`